### PR TITLE
chore(debian): exclude platform wallpapers from dh_install

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,8 @@
 
 export USE_NONFREEPIC = 1
 
+override_dh_install:
+	dh_install --exclude=deepin/platform --exclude=deepin-livewallpapers/platform
 
 %:
 	dh $@ 


### PR DESCRIPTION
1. Added override_dh_install to skip platform-specific wallpaper directories

Log: Exclude deepin/platform and deepin-livewallpapers/platform from install

chore(debian): 在 dh_install 中排除 platform 壁纸目录

1. 新增 override_dh_install 以跳过平台特定的壁纸目录

Log: 安装时排除 deepin/platform 和 deepin-livewallpapers/platform 目录